### PR TITLE
Update auth token retrieval and node urls

### DIFF
--- a/piptv_pmg/pmg.py
+++ b/piptv_pmg/pmg.py
@@ -10,23 +10,23 @@ class M3UWriter(object):
         self.cdn_nodes = ['s6.ustvgo.org', 's8.ustvgo.org', 's9.ustvgo.org', 's11.ustvgo.org']
 
         self.channel_codes = ['ABCE', 'A&E', 'AMC', 'APL', 'BBCA', 'BET', 'BOOM', 'BRVO', 'CNE', 'CBSE', 'CMT', 'CNBC',
-                              'CNN', 'COM', 'DEST', 'DSC', 'DISE', 'DISJR', 'DXD', 'DIY', 'E!', 'ESPN', 'ESPN2', 'FOOD',
+                              'CNN', 'COM', 'CW', 'DEST', 'DSC', 'DISE', 'DISJR', 'DXD', 'DIY', 'E!', 'ESPN', 'ESPN2', 'FOOD',
                               'FBN', 'FOXE', 'FNC', 'FS1', 'FS2', 'FREEFM', 'FX', 'FXM', 'FXX', 'GOLF', 'GSN', 'HALL',
                               'HMM', 'HBO', 'HGTV', 'HIST', 'HLN', 'ID', 'LIFE', 'LIFEMOV', 'MLBN', 'MTHD', 'MSNBC',
                               'MTV', 'NGW', 'NGC', 'NBA', 'NBCSN', 'NBCE', 'NFLHD', 'NIKE', 'NKTN', 'OWN', 'OXGN',
-                              'PAR', 'PBSE', 'POP', 'SCI', 'SHO', 'STARZ', 'SUND', 'SYFY', 'TBS', 'TCM', 'TELE', 'TNNS',
-                              'CWE', 'WEATH', 'TLC', 'TNT', 'TRAV', 'TruTV', 'TVLD', 'UNVSO', 'USA', 'VH1', 'WE']
+                              'PAR', 'PBSE', 'POP', 'SCI', 'SHOW', 'STARZ', 'SUND', 'SYFY', 'TBS', 'TCM', 'TELE', 'TNNS',
+                              'CWE', 'WEATH', 'TLC', 'TNT', 'TOON', 'TRAV', 'TruTV', 'TVLD', 'UNVSO', 'USA', 'VH1', 'WE']
 
         self.cdn_channel_codes = ['ABC', 'AE', 'AMC', 'Animal', 'BBCAmerica', 'BET', 'Boomerang', 'Bravo', 'CN', 'CBS',
-                                  'CMT', 'CNBC', 'CNN', 'Comedy', 'DA', 'Discovery', 'Disney', 'DisneyJr', 'DisneyXD',
+                                  'CMT', 'CNBC', 'CNN', 'Comedy', 'CW', 'DA', 'Discovery', 'Disney', 'DisneyJr', 'DisneyXD',
                                   'DIY', 'E', 'ESPN', 'ESPN2', 'FoodNetwork', 'FoxBusiness', 'FOX', 'FoxNews', 'FS1',
                                   'FS2', 'Freeform', 'FX', 'FXMovie', 'FXX', 'GOLF', 'GSN', 'Hallmark', 'HMM', 'HBO',
                                   'HGTV', 'History', 'HLN', 'ID', 'Lifetime', 'LifetimeM', 'MLB', 'MotorTrend', 'MSNBC',
                                   'MTV', 'NatGEOWild', 'NatGEO', 'NBA', 'NBCSN', 'NBC', 'NFL', 'Nickelodeon',
                                   'Nicktoons', 'OWN', 'Oxygen', 'Paramount', 'PBS', 'POP', 'Science', 'Showtime',
                                   'StarZ', 'SundanceTV', 'SYFY', 'TBS', 'TCM', 'Telemundo', 'Tennis', 'CWE',
-                                  'https://weather-lh.akamaihd.net/i/twc_1@92006/master.m3u8', 'TLC', 'TNT', 'Travel',
-                                  'TruTV', 'TVLand', 'Univision', 'USANetwork', 'VH1', 'WETV']
+                                  'https://weather-lh.akamaihd.net/i/twc_1@92006/master.m3u8', 'TLC', 'TNT', 'CN',
+                                  'Travel', 'TruTV', 'TVLand', 'Univision', 'USANetwork', 'VH1', 'WETV']
 
         self.headers = {"User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:71.0) Gecko/20100101 Firefox/71.0"}
         self.write_dir = write_dir
@@ -50,9 +50,9 @@ class M3UWriter(object):
 
     def retrieve_new_token(self):
         print("\nWorking some black magic..\n")
-        streamUrl = requests.post(self.renew_token_node, data=self.renew_token_node_post_data).text
-        authToken = streamUrl.split("wmsAuthSign=")[1]
-        self.wms_auth_token.update({"wmsAuthSign": authToken})
+        stream_url = requests.post(self.renew_token_node, data=self.renew_token_node_post_data).text
+        auth_token = stream_url.split("wmsAuthSign=")[1]
+        self.wms_auth_token.update({"wmsAuthSign": auth_token})
         print("\nToken retrieved: {}\n".format(self.wms_auth_token['wmsAuthSign']))
 
     def initialize_m3u_file(self):

--- a/piptv_pmg/pmg.py
+++ b/piptv_pmg/pmg.py
@@ -3,7 +3,6 @@ import sys
 import getopt
 import random
 import requests
-from bs4 import BeautifulSoup as Soup
 
 
 class M3UWriter(object):
@@ -51,8 +50,9 @@ class M3UWriter(object):
 
     def retrieve_new_token(self):
         print("\nWorking some black magic..\n")
-        bsoup = Soup(requests.post(self.renew_token_node, data=self.renew_token_node_post_data).text, 'html.parser')
-        self.wms_auth_token.update({"wmsAuthSign": bsoup.text.split("wmsAuthSign=")[1]})
+        streamUrl = requests.post(self.renew_token_node, data=self.renew_token_node_post_data).text
+        authToken = streamUrl.split("wmsAuthSign=")[1]
+        self.wms_auth_token.update({"wmsAuthSign": authToken}
         print("\nToken retrieved: {}\n".format(self.wms_auth_token['wmsAuthSign']))
 
     def initialize_m3u_file(self):

--- a/piptv_pmg/pmg.py
+++ b/piptv_pmg/pmg.py
@@ -8,7 +8,7 @@ from bs4 import BeautifulSoup as Soup
 
 class M3UWriter(object):
     def __init__(self, write_dir):
-        self.cdn_nodes = ['peer1.ustv.to', 'peer2.ustv.to', 'peer3.ustv.to']
+        self.cdn_nodes = ['s6.ustvgo.org', 's8.ustvgo.org', 's9.ustvgo.org', 's11.ustvgo.org']
 
         self.channel_codes = ['ABCE', 'A&E', 'AMC', 'APL', 'BBCA', 'BET', 'BOOM', 'BRVO', 'CNE', 'CBSE', 'CMT', 'CNBC',
                               'CNN', 'COM', 'DEST', 'DSC', 'DISE', 'DISJR', 'DXD', 'DIY', 'E!', 'ESPN', 'ESPN2', 'FOOD',
@@ -31,7 +31,8 @@ class M3UWriter(object):
 
         self.headers = {"User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:71.0) Gecko/20100101 Firefox/71.0"}
         self.write_dir = write_dir
-        self.renew_token_node = 'https://ustvgo.tv/player.php?stream=NFL'
+        self.renew_token_node = 'https://ustvgo.tv/data.php'
+        self.renew_token_node_post_data = {"stream": "NFL"}
         self.wms_auth_token = {}
         self.generated_links = []
 
@@ -50,9 +51,8 @@ class M3UWriter(object):
 
     def retrieve_new_token(self):
         print("\nWorking some black magic..\n")
-        bsoup = Soup(requests.get(self.renew_token_node).text, 'html.parser')
-        self.wms_auth_token.update({"wmsAuthSign": bsoup.text.split("file: \'")[1].split("\'")
-                                   [0].split("wmsAuthSign=")[1]})
+        bsoup = Soup(requests.post(self.renew_token_node, data=self.renew_token_node_post_data).text, 'html.parser')
+        self.wms_auth_token.update({"wmsAuthSign": bsoup.text.split("wmsAuthSign=")[1]})
         print("\nToken retrieved: {}\n".format(self.wms_auth_token['wmsAuthSign']))
 
     def initialize_m3u_file(self):

--- a/piptv_pmg/pmg.py
+++ b/piptv_pmg/pmg.py
@@ -52,7 +52,7 @@ class M3UWriter(object):
         print("\nWorking some black magic..\n")
         streamUrl = requests.post(self.renew_token_node, data=self.renew_token_node_post_data).text
         authToken = streamUrl.split("wmsAuthSign=")[1]
-        self.wms_auth_token.update({"wmsAuthSign": authToken}
+        self.wms_auth_token.update({"wmsAuthSign": authToken})
         print("\nToken retrieved: {}\n".format(self.wms_auth_token['wmsAuthSign']))
 
     def initialize_m3u_file(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 setuptools==41.2.0
 requests==2.22.0
-beautifulsoup4==4.8.1

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name="piptv_pmg",
-    version="0.2.0",
+    version="0.2.1",
     author="Brett Hufnagle",
     author_email="teachingchain0420@gmail.com",
     description="Piptv M3U Generator - An M3U IPTV playlist generator using piptvs scraping logic",


### PR DESCRIPTION
Updated the auth token retrieval and the node urls. I am now able to get a valid m3u file that works. I have tested the resulting m3u8 links in VLC, and have also tested the m3u file in Jellyfin Live Tv (Plex/Emby alternative) and the streaming works correctly there as well.

Bumped the version number to 0.2.1. Can change this to something else if desired.

Should close out #14 #15 #18 